### PR TITLE
Improve visibility of clocks by bringing hovered capitals to front

### DIFF
--- a/europe-clocks.html
+++ b/europe-clocks.html
@@ -294,9 +294,12 @@
                     })
                 }).addTo(map);
 
-                // Add hover event listeners to bring marker to front
+                // Add hover event listeners to adjust marker stacking using zIndexOffset
                 marker.on('mouseover', function() {
-                    this.bringToFront();
+                    this.setZIndexOffset(1000);
+                });
+                marker.on('mouseout', function() {
+                    this.setZIndexOffset(0);
                 });
 
                 currentMarkers.push(marker);


### PR DESCRIPTION
- Add mouseover event listener to each marker
- Call  setZIndexOffset when hovering to ensure visibility over overlapping clocks
- Fixes issue #4